### PR TITLE
Patient History and Past Visits

### DIFF
--- a/client/public/css/style.css
+++ b/client/public/css/style.css
@@ -577,3 +577,51 @@ label {
     margin: 50px 0;
   }
 }
+
+.animated {
+  -webkit-animation-duration: 10s;
+  animation-duration: 10s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+}
+
+@-webkit-keyframes fadeOut {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes fadeOut {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@-webkit-keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.fadeIn {
+  -webkit-animation-name: fadeIn;
+  animation-name: fadeIn;
+}

--- a/client/public/css/style.css
+++ b/client/public/css/style.css
@@ -585,22 +585,13 @@ label {
   animation-fill-mode: both;
 }
 
-@-webkit-keyframes fadeOut {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-@keyframes fadeOut {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
+.animated-fade[data-animating="1"] {
+  -webkit-animation-name: fadeIn;
+  animation-name: fadeIn;
+  -webkit-animation-duration: 0.5s;
+  animation-duration: 0.5s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
 }
 
 @-webkit-keyframes fadeIn {

--- a/client/src/ehr_components/History.tsx
+++ b/client/src/ehr_components/History.tsx
@@ -1,91 +1,175 @@
-import { useHistory } from "react-router-dom";
+import { useLocation, useHistory } from "react-router-dom";
 import { toastr } from "react-redux-toastr";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
+import Axios from "axios";
 
 import Field from "./ui/Field";
-import TextArea from "./ui/Textarea";
-import Radio from "./ui/Radio";
 import AutoComplete from "./ui/AutoComplete";
-import { bloodGroups, diseases, yesOrNoOptions } from "./data/patient-history";
-import Button from "./ui/button";
+import { bloodGroups, diseases } from "./data/patient-history";
+import { Patient, PatientHistory } from "./NewPatient";
+import FieldRenderer from "./common_components/field-renderer";
+import generatePatientHistoryFields from "./data/patient-history-fields";
 
-export interface HistoryProps {
-  added: Function;
+interface ChronicDisease {
+  label: string;
 }
 
-interface History {
-  note?: string;
-}
-interface User {
-  address?: string;
-  age?: string;
-  dob?: string;
-  fullName: string;
-  gender?: string;
-  job?: string;
-  label?: string;
-  maritialStatus?: string;
-  number?: string;
-  history?: History;
+interface PatientHistoryRendered extends PatientHistory {
+  chronic_diseases: ChronicDisease[];
 }
 
-const initialState: any = {
+const initialHistoryState: PatientHistoryRendered = {
+  patient: "",
+  chronic_diseases: [],
+  previous_admission: "",
+  previous_admission_description: "",
+  past_surgery: "",
+  past_surgery_description: "",
   fractures: "",
-  previous_admission: "no",
-  past_surgery: "no",
-  drug_allergy: "no",
-  chronic_diseases: "",
-  chronic_drug_usage: "yes",
-  smoking_status: "no",
-  alcohol: "yes"
+  family_history: "",
+  drug_allergy: "",
+  drug_allergy_description: "",
+  chronic_drug_usage: "",
+  blood_group: "",
+  smoking_status: "",
+  alcohol: "",
+  notes: ""
 };
 
-const firebaseURl =
-  "https://idoctorpwa-default-rtdb.firebaseio.com/patients.json";
+const History: React.FC = () => {
+  let history = useHistory();
+  let { state: patientState } = useLocation<Patient>();
 
-const History: React.FC<HistoryProps> = props => {
-  let [medicalHistory, setMedicalHistory] = useState(initialState);
-  const history = useHistory();
-  let currentUser: User = history.location.state as User;
+  const [changedField, setChangedField] = useState("");
+  let [medicalHistory, setMedicalHistory] = useState<PatientHistory>(() => {
+    let chronicDiseases = patientState?.history?.chronic_diseases as string[];
 
-  useEffect(() => {
-    console.log("History note: ", currentUser.history?.note);
-    setMedicalHistory({ ...medicalHistory, notes: currentUser.history?.note });
-  }, []);
+    let mappedChronicDiseases: ChronicDisease[] = [];
+    if (chronicDiseases !== undefined) {
+      mappedChronicDiseases = chronicDiseases.map((disease: string) => ({
+        label: disease
+      }));
+    }
 
-  let handleClick = async () => {
-    console.log(medicalHistory);
-
-    // try {
-    //   var callResults = await Axios.post(firebaseURl, medicalHistory);
-    //   //history.push(`/main/search#success`);
-    //   toastr.success("Patient Medical History", "Added Successfully");
-    // } catch (error) {
-    //   toastr.error("Error:", error.message);
-    // }
-    toastr.success("Patient Medical History", "Added Successfully");
-  };
+    return {
+      ...initialHistoryState,
+      ...patientState.history,
+      chronic_diseases: mappedChronicDiseases,
+      patient: patientState.id || ""
+    };
+  });
 
   function handleFieldChange(
     fieldName: string,
-    event:
-      | React.ChangeEvent<HTMLInputElement>
-      | React.ChangeEvent<HTMLTextAreaElement>
+    event: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
   ) {
-    medicalHistory[fieldName] = event.target.value;
-    setMedicalHistory({ ...medicalHistory });
+    setChangedField(fieldName);
+
+    let { value } = event.target;
+    setMedicalHistory(prevState => {
+      let newState = { ...prevState };
+      newState[fieldName as keyof PatientHistory] = value;
+      return newState;
+    });
   }
 
   function handleBloodGroupChange(options: Array<any>) {
-    let value = options && options[0] ? options[0].value : "";
-    medicalHistory.blood_group = value;
-    setMedicalHistory({ ...medicalHistory });
+    let value = options && options[0] ? options[0].label : "";
+    setMedicalHistory(prevState => {
+      let newState = { ...prevState };
+      newState.blood_group = value;
+      return newState;
+    });
   }
 
   function handleDiseaseChange(options: Array<any>) {
-    medicalHistory.chronic_diseases = options;
-    setMedicalHistory({ ...medicalHistory });
+    let selected = options.map(option => ({ label: option.label }));
+    setMedicalHistory(prevState => {
+      let newState = { ...prevState };
+      newState.chronic_diseases = selected;
+      return newState;
+    });
   }
+
+  let fieldData = generatePatientHistoryFields({
+    onChangeHandler: handleFieldChange,
+    changedField,
+    formData: medicalHistory
+  });
+
+  let handleClick = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    try {
+      let chronic_diseases = medicalHistory.chronic_diseases.map(
+        disease => disease.label
+      );
+      let response = await Axios.patch("/api/patient/history", {
+        ...medicalHistory,
+        chronic_diseases
+      });
+      console.log("UPDATED HISTORY", response.data.patient);
+      toastr.success("Patient History", "Updated Successfully");
+      history.push("/main/search");
+    } catch (error: any) {
+      let message;
+      if (error.response) {
+        if (error.response.data.errors) {
+          let errors = error.response.data.errors as string[];
+          message = errors.join(". ");
+        } else {
+          message = error.response.data.message;
+        }
+      } else {
+        message = error.message;
+      }
+      toastr.error("Patient History", message);
+    }
+  };
+
+  let fields = fieldData.map(field => {
+    if (field.name === "chronic_diseases") {
+      return (
+        <Field
+          name="chronic_diseases"
+          label="Chronic Diseases"
+          key={field.name}
+          isFormRow={true}
+        >
+          <AutoComplete
+            name="Chronic Diseases"
+            placeholder="Chronic Diseases"
+            multiple={true}
+            options={diseases}
+            defaultSelected={medicalHistory.chronic_diseases}
+            onSelect={handleDiseaseChange}
+          />
+        </Field>
+      );
+    } else if (field.name === "blood_group") {
+      let { blood_group } = medicalHistory;
+      return (
+        <Field
+          name="blood_group"
+          label="Blood Group"
+          key={field.name}
+          isFormRow={true}
+        >
+          <AutoComplete
+            name="Blood Group"
+            placeholder="Blood Group"
+            options={bloodGroups}
+            defaultSelected={blood_group ? [blood_group] : undefined}
+            onSelect={handleBloodGroupChange}
+          />
+        </Field>
+      );
+    } else {
+      return <FieldRenderer field={field} key={field.name} />;
+    }
+  });
 
   return (
     <div>
@@ -93,151 +177,10 @@ const History: React.FC<HistoryProps> = props => {
 
       <div className="mx-auto" style={{ width: "90%" }}>
         <div className="row">
-          <form className="col-9">
-            <Field name="chronic_diseases" label="Chronic Diseases">
-              <AutoComplete
-                name="Chronic Diseases"
-                placeholder="Chronic Diseases"
-                multiple={true}
-                options={diseases}
-                onSelect={handleDiseaseChange}
-              />
-            </Field>
-
-            <Field
-              name="previous_admission"
-              label="Previous Admission to the hospital"
-            >
-              <>
-                <Radio
-                  name="previous_admission"
-                  options={yesOrNoOptions}
-                  value={medicalHistory.previous_admission}
-                  onChange={handleFieldChange}
-                />
-                {medicalHistory.previous_admission === "yes" ? (
-                  <TextArea
-                    className="mt-2"
-                    name="previous_admission_description"
-                    placeholder="Add details about the previous admission"
-                    value={medicalHistory.previous_admission_description}
-                    onChange={handleFieldChange}
-                  />
-                ) : (
-                  <></>
-                )}
-              </>
-            </Field>
-
-            <Field name="past_surgery" label="Past Surgery">
-              <>
-                <Radio
-                  name="past_surgery"
-                  options={yesOrNoOptions}
-                  value={medicalHistory.past_surgery}
-                  onChange={handleFieldChange}
-                />
-                {medicalHistory.past_surgery === "yes" ? (
-                  <TextArea
-                    className="mt-2"
-                    name="past_surgery_description"
-                    placeholder="Add details about the past surgery"
-                    value={medicalHistory.past_surgery_description}
-                    onChange={handleFieldChange}
-                  />
-                ) : (
-                  <></>
-                )}
-              </>
-            </Field>
-
-            <Field name="fractures" label="Fractures">
-              <TextArea
-                name="fractures"
-                placeholder="Add details about any past fractures"
-                value={medicalHistory.fractures}
-                onChange={handleFieldChange}
-              />
-            </Field>
-
-            <Field name="family_history" label="Family History">
-              <TextArea
-                name="family_history"
-                placeholder="Add details about the family history"
-                value={medicalHistory.family_history}
-                onChange={handleFieldChange}
-              />
-            </Field>
-
-            <Field name="drug_allergy" label="Drug Allergy">
-              <>
-                <Radio
-                  name="drug_allergy"
-                  options={yesOrNoOptions}
-                  value={medicalHistory.drug_allergy}
-                  onChange={handleFieldChange}
-                />
-                {medicalHistory.drug_allergy === "yes" ? (
-                  <TextArea
-                    className="mt-2"
-                    name="drug_allergy_description"
-                    placeholder="Add details about the drug allergies"
-                    value={medicalHistory.drug_allergy_description}
-                    onChange={handleFieldChange}
-                  />
-                ) : (
-                  <></>
-                )}
-              </>
-            </Field>
-
-            <Field name="chronic_drug_usage" label="Chronic use of Drugs">
-              <Radio
-                name="chronic_drug_usage"
-                options={yesOrNoOptions}
-                value={medicalHistory.chronic_drug_usage}
-                onChange={handleFieldChange}
-              />
-            </Field>
-
-            <Field name="blood_group" label="Blood Group">
-              <AutoComplete
-                name="Blood Group"
-                placeholder="Blood Group"
-                options={bloodGroups}
-                onSelect={handleBloodGroupChange}
-              />
-            </Field>
-
-            <Field name="smoking_status" label="Smoking Status">
-              <Radio
-                name="smoking_status"
-                options={yesOrNoOptions}
-                value={medicalHistory.smoking_status}
-                onChange={handleFieldChange}
-              />
-            </Field>
-
-            <Field name="alcohol" label="Alcohol Drinking">
-              <Radio
-                name="alcohol"
-                options={yesOrNoOptions}
-                value={medicalHistory.alcohol}
-                onChange={handleFieldChange}
-              />
-            </Field>
-
-            <Field name="notes" label="Notes">
-              <TextArea
-                name="notes"
-                placeholder="add any additional notes"
-                value={medicalHistory.notes}
-                onChange={handleFieldChange}
-              />
-            </Field>
-
+          <form className="col-9" onSubmit={handleClick}>
+            {fields}
             <div className="form-group">
-              <Button onClick={handleClick}>Add</Button>
+              <button className="bttn-custom">Add</button>
             </div>
           </form>
 
@@ -249,10 +192,8 @@ const History: React.FC<HistoryProps> = props => {
                 alt="Patient"
               />
               <div className="card-body">
-                <h5 className="card-title">{currentUser.fullName}</h5>
-                <a href="#" className="btn btn-primary">
-                  Update Image
-                </a>
+                <h5 className="card-title">{patientState.fullName}</h5>
+                <button className="btn btn-primary">Update Image</button>
               </div>
             </div>
           </div>

--- a/client/src/ehr_components/History.tsx
+++ b/client/src/ehr_components/History.tsx
@@ -180,7 +180,7 @@ const History: React.FC = () => {
           <form className="col-9" onSubmit={handleClick}>
             {fields}
             <div className="form-group">
-              <button className="bttn-custom">Add</button>
+              <button className="bttn-custom">Update</button>
             </div>
           </form>
 

--- a/client/src/ehr_components/History.tsx
+++ b/client/src/ehr_components/History.tsx
@@ -42,7 +42,11 @@ const History: React.FC = () => {
 
   const [changedField, setChangedField] = useState("");
   let [medicalHistory, setMedicalHistory] = useState<PatientHistory>(() => {
-    let chronicDiseases = patientState?.history?.chronic_diseases as string[];
+    if (patientState === undefined) {
+      return { ...initialHistoryState, patient: "" };
+    }
+
+    let chronicDiseases = patientState.history?.chronic_diseases as string[];
 
     let mappedChronicDiseases: ChronicDisease[] = [];
     if (chronicDiseases !== undefined) {
@@ -170,6 +174,11 @@ const History: React.FC = () => {
       return <FieldRenderer field={field} key={field.name} />;
     }
   });
+
+  if (patientState === undefined) {
+    history.push("/main/search");
+    return <></>;
+  }
 
   return (
     <div>

--- a/client/src/ehr_components/Main.tsx
+++ b/client/src/ehr_components/Main.tsx
@@ -11,6 +11,7 @@ import Search from "./Search";
 import History from "./History";
 import NewVisit from "./NewVisit";
 import NewPatient from "./NewPatient";
+import Visits from "./Visits/";
 
 export interface MainProps {}
 
@@ -34,6 +35,7 @@ const Main: React.FC<MainProps> = () => {
       <Switch>
         <Route path={`${path}/search`} component={Search} />
         <Route path={`${path}/history`} component={History} />
+        <Route path={`${path}/visits`} component={Visits} />
         <Route path={`${path}/newVisit`} component={NewVisit} />
         <Route path={`${path}/newPatient`} component={NewPatient} />
         <Redirect to={`${path}/search`} />

--- a/client/src/ehr_components/NewPatient.tsx
+++ b/client/src/ehr_components/NewPatient.tsx
@@ -6,20 +6,29 @@ import Axios from "axios";
 import FieldRenderer from "./common_components/field-renderer";
 import generateNewPatientFields from "./data/new-patient-fields";
 
-export interface PatientHistory {
-  chronic_diseases: string;
+interface ObjectKeyAccess {
+  [key: string]: string | any[] | PatientHistory | undefined;
+}
+
+export interface PatientHistory extends ObjectKeyAccess {
+  patient: string;
+  chronic_diseases: any[];
   previous_admission: string;
+  previous_admission_description: string;
   past_surgery: string;
+  past_surgery_description: string;
   fractures: string;
   family_history: string;
   drug_allergy: string;
+  drug_allergy_description: string;
   chronic_drug_usage: string;
+  blood_group: string;
   smoking_status: string;
   alcohol: string;
   notes: string;
 }
 
-export interface Patient {
+export interface Patient extends ObjectKeyAccess {
   id?: string;
   fullName: string;
   dob: string;
@@ -50,9 +59,11 @@ const NewPatient: React.FC = () => {
     fieldName: string,
     event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
-    setFormData({
-      ...formData,
-      [fieldName]: event.target.value
+    let { value } = event.target;
+    setFormData(prevState => {
+      let newState = { ...prevState };
+      newState[fieldName] = value;
+      return newState;
     });
   };
 

--- a/client/src/ehr_components/NewVisit.tsx
+++ b/client/src/ehr_components/NewVisit.tsx
@@ -46,7 +46,7 @@ const NewVisit: React.FC<VisitProps> = () => {
 
   let [medicalVisit, setMedicalVisit] = useState<PatientVisit>({
     ...initialVisitState,
-    patient: patientState && (patientState.id || "")
+    patient: patientState?.id || ""
   });
 
   const [isFormSubmitted, setIsFormSubmitted] = useState(false);

--- a/client/src/ehr_components/NewVisit.tsx
+++ b/client/src/ehr_components/NewVisit.tsx
@@ -15,6 +15,7 @@ export interface VisitProps {
 }
 
 const initialVisitState: PatientVisit = {
+  id: "",
   patient: "",
   date: "",
   complaint: "",
@@ -184,7 +185,7 @@ const NewVisit: React.FC<VisitProps> = () => {
                 alt="Patient"
               />
               <div className="card-body">
-                <h5 className="card-title">Joey</h5>
+                <h5 className="card-title">{patientState.fullName}</h5>
                 <button className="btn btn-primary">Update Image</button>
               </div>
             </div>

--- a/client/src/ehr_components/NewVisit.tsx
+++ b/client/src/ehr_components/NewVisit.tsx
@@ -46,7 +46,7 @@ const NewVisit: React.FC<VisitProps> = () => {
 
   let [medicalVisit, setMedicalVisit] = useState<PatientVisit>({
     ...initialVisitState,
-    patient: patientState.id || ""
+    patient: patientState && (patientState.id || "")
   });
 
   const [isFormSubmitted, setIsFormSubmitted] = useState(false);
@@ -163,6 +163,11 @@ const NewVisit: React.FC<VisitProps> = () => {
       return <FieldRenderer field={field} key={field.name} />;
     }
   });
+
+  if (patientState === undefined) {
+    history.push("/main/search");
+    return <></>;
+  }
 
   return (
     <div>

--- a/client/src/ehr_components/SearchTable/ActionsCell.tsx
+++ b/client/src/ehr_components/SearchTable/ActionsCell.tsx
@@ -6,6 +6,7 @@ export default function ActionsCell<T extends Record<string, unknown>>(
   cell: React.PropsWithChildren<CellProps<T>>
 ) {
   let patient = useState(cell.data[cell.row.index].patient)[0];
+  let visitsCount = patient.visits.length;
   const history = useHistory();
 
   let handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -21,11 +22,14 @@ export default function ActionsCell<T extends Record<string, unknown>>(
     <Fragment>
       <div className="text-left text-md-right">
         <button
-          className="btn btn-outline-primary"
+          disabled={visitsCount === 0}
+          className={`btn btn-outline-${
+            visitsCount === 0 ? "secondary" : "primary"
+          }`}
           onClick={handleClick}
-          name="history"
+          name="visits"
         >
-          Edit History
+          {`${visitsCount} Past Visit${visitsCount === 1 ? "" : "s"}`}
         </button>
         <button
           className="btn btn-outline-primary ml-4"
@@ -33,6 +37,13 @@ export default function ActionsCell<T extends Record<string, unknown>>(
           name="newVisit"
         >
           New Visit
+        </button>
+        <button
+          className="btn btn-outline-primary ml-4"
+          onClick={handleClick}
+          name="history"
+        >
+          Medical History
         </button>
       </div>
     </Fragment>

--- a/client/src/ehr_components/SearchTable/ActionsCell.tsx
+++ b/client/src/ehr_components/SearchTable/ActionsCell.tsx
@@ -5,7 +5,7 @@ import { CellProps } from "react-table";
 export default function ActionsCell<T extends Record<string, unknown>>(
   cell: React.PropsWithChildren<CellProps<T>>
 ) {
-  let [patient, setPatient] = useState(cell.data[cell.row.index].patient);
+  let patient = useState(cell.data[cell.row.index].patient)[0];
   const history = useHistory();
 
   let handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/client/src/ehr_components/SearchTable/DefaultColumnFilter.tsx
+++ b/client/src/ehr_components/SearchTable/DefaultColumnFilter.tsx
@@ -33,8 +33,9 @@ export default function DefaultColumnFilter<T extends Record<string, unknown>>({
       placeholder={`Patient ${render("Header")}`}
       options={options}
       onSelect={(selected: any) => {
-        let filter = selected.length > 0 ? selected[0].value : "";
-        setFilter(filter);
+        if (selected.length > 0) {
+          setFilter(selected[0].value);
+        }
       }}
       onKeyDown={(e: Event) => {
         let { key } = e as KeyboardEvent;

--- a/client/src/ehr_components/SearchTable/DefaultColumnFilter.tsx
+++ b/client/src/ehr_components/SearchTable/DefaultColumnFilter.tsx
@@ -47,6 +47,7 @@ export default function DefaultColumnFilter<T extends Record<string, unknown>>({
         let { value } = e.target as HTMLInputElement;
         setFilter(value.trim());
       }}
+      onClear={() => setFilter("")}
       className="mb-4"
     />
   );

--- a/client/src/ehr_components/Visits/VisitInfo.tsx
+++ b/client/src/ehr_components/Visits/VisitInfo.tsx
@@ -1,0 +1,86 @@
+import { PatientVisit } from "../data/new-visit-fields";
+
+interface VisitInfoProps {
+  className: string;
+  selectedVisit?: PatientVisit;
+  isAnimating: number;
+  setIsAnimating: Function;
+}
+
+let sectionTitles = [
+  ["date", "Date of Visit"],
+  ["complaint", "Chief Complaint"],
+  ["present_illness_history", "History of Present Illness"],
+  ["other_system_review", "Review of Other Systems"],
+  ["bp", "Blood Pressure"],
+  ["pulse_rate", "Pulse Rate"],
+  ["temperature", "Body Temperature"],
+  ["respiratory_rate", "Respiratory Rate"],
+  ["spo2", "Spo2"],
+  ["weight", "Weight"],
+  ["height", "Height"],
+  ["bmi", "Body Mass Index"],
+  ["lab_investigation", "Imaging and laboratory Investigations"],
+  ["diagnosis", "Diagnosis"],
+  ["treatment", "Treatment"],
+  ["is_free", "Free Visit"],
+  ["is_review", "Visit Review"],
+  ["is_referred", "Referred"],
+  ["cost", "Visit Cost"],
+  ["notes", "Notes"]
+];
+
+export default function VisitInfo(props: VisitInfoProps) {
+  let { className, selectedVisit, isAnimating, setIsAnimating } = props;
+
+  if (!selectedVisit) return <></>;
+
+  let displayedInfo = [];
+  for (let section of sectionTitles) {
+    let [key, title] = section;
+    let text;
+
+    if (key === "bp") {
+      let diaValue = selectedVisit["bp_dia"];
+      let bpValue = selectedVisit["bp_sys"];
+      text = (
+        <>
+          <p className={`p-0 m-0 ${diaValue ? "" : "text-secondary"}`}>
+            {`DIA: ${diaValue || "Not specified"}`}
+          </p>
+          <p className={`p-0 m-0 ${bpValue ? "" : "text-secondary"}`}>
+            {`SYS: ${bpValue || "Not specified"}`}
+          </p>
+        </>
+      );
+    } else {
+      let value = selectedVisit[key as keyof PatientVisit];
+      text = (
+        <p className={`p-0 m-0 ${value ? "" : "text-secondary"}`}>
+          {value || "Not specified"}
+        </p>
+      );
+    }
+
+    let sectionElement = (
+      <div className={key !== "notes" ? "mb-4" : ""} key={key}>
+        <h5>{title}</h5>
+        {text}
+      </div>
+    );
+
+    displayedInfo.push(sectionElement);
+  }
+
+  return (
+    <div className={className}>
+      <div
+        className="card shadow-sm p-4 animated-fade"
+        onAnimationEnd={() => setIsAnimating(0)}
+        data-animating={isAnimating}
+      >
+        {displayedInfo}
+      </div>
+    </div>
+  );
+}

--- a/client/src/ehr_components/Visits/VisitsList.tsx
+++ b/client/src/ehr_components/Visits/VisitsList.tsx
@@ -1,0 +1,42 @@
+import { PatientVisit } from "../data/new-visit-fields";
+
+interface VisitsListProps {
+  className: string;
+  visits: PatientVisit[];
+  selectedVisit?: PatientVisit;
+  onSelect: (id: string) => void;
+}
+
+export default function VisitsList(props: VisitsListProps) {
+  let { className, visits, selectedVisit, onSelect } = props;
+
+  let rows = visits.map(visit => {
+    let { date, complaint, id } = visit;
+    let isSelected = selectedVisit?.id === id;
+
+    let handleSelect = () => {
+      onSelect(id);
+    };
+
+    return (
+      <button
+        className={`list-group-item text-left ${isSelected ? "active" : ""}`}
+        key={id}
+        onClick={handleSelect}
+      >
+        <p>{complaint}</p>
+        <p className={`p-0 m-0 ${isSelected ? "" : "text-secondary"}`}>
+          {date}
+        </p>
+      </button>
+    );
+  });
+
+  return (
+    <div className={className}>
+      <div className="card overflow-auto" style={{ maxHeight: 400 }}>
+        <div className="list-group list-group-flush">{rows}</div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/ehr_components/Visits/index.tsx
+++ b/client/src/ehr_components/Visits/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useHistory } from "react-router-dom";
 import Axios from "axios";
 
 import VisitsList from "./VisitsList";
@@ -11,12 +11,14 @@ export default function Visits() {
   const [isAnimating, setIsAnimating] = useState(0);
   const [visitsList, setVisitsList] = useState<PatientVisit[]>([]);
   const [selectedVisit, setSelectedVisit] = useState<PatientVisit>();
-  let {
-    state: { id: patientId }
-  } = useLocation<Patient>();
+  let history = useHistory();
+  let { state: patientState } = useLocation<Patient>();
+  let patientId = patientState && patientState.id ? patientState.id : "";
 
   useEffect(() => {
     console.log(new Date(Date.now()).toISOString(), "FETCHING VISITS");
+
+    if (patientId.length === 0) return;
 
     let getVisits = async () => {
       let {
@@ -41,6 +43,11 @@ export default function Visits() {
     setIsAnimating(1);
     setSelectedVisit(newSelectedVisit);
   };
+
+  if (patientState === undefined) {
+    history.push("/main/search");
+    return <></>;
+  }
 
   return (
     <div className="container text-left mb-5">

--- a/client/src/ehr_components/Visits/index.tsx
+++ b/client/src/ehr_components/Visits/index.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import Axios from "axios";
+
+import VisitsList from "./VisitsList";
+import VisitInfo from "./VisitInfo";
+import { Patient } from "../NewPatient";
+import { PatientVisit } from "../data/new-visit-fields";
+
+export default function Visits() {
+  const [isAnimating, setIsAnimating] = useState(0);
+  const [visitsList, setVisitsList] = useState<PatientVisit[]>([]);
+  const [selectedVisit, setSelectedVisit] = useState<PatientVisit>();
+  let {
+    state: { id: patientId }
+  } = useLocation<Patient>();
+
+  useEffect(() => {
+    console.log(new Date(Date.now()).toISOString(), "FETCHING VISITS");
+
+    let getVisits = async () => {
+      let {
+        data: { visits }
+      } = await Axios.get(`/api/visits/patient/${patientId}`);
+
+      console.log(
+        new Date(Date.now()).toISOString(),
+        "RETRIEVED VISITS",
+        visits
+      );
+
+      setVisitsList(visits);
+      setSelectedVisit(visits[0]);
+    };
+
+    getVisits();
+  }, [patientId]);
+
+  let handleSelect = (id: string) => {
+    let newSelectedVisit = visitsList.find(visit => visit.id === id);
+    setIsAnimating(1);
+    setSelectedVisit(newSelectedVisit);
+  };
+
+  return (
+    <div className="container text-left mb-5">
+      <h3 className="mb-3">Past Visits</h3>
+      <div className="row">
+        <VisitsList
+          className="col-md-4 mb-4"
+          visits={visitsList}
+          selectedVisit={selectedVisit}
+          onSelect={handleSelect}
+        />
+        <VisitInfo
+          className="col-md-8 align-self-start"
+          selectedVisit={selectedVisit}
+          isAnimating={isAnimating}
+          setIsAnimating={setIsAnimating}
+        />
+      </div>
+    </div>
+  );
+}

--- a/client/src/ehr_components/common_components/field-renderer.tsx
+++ b/client/src/ehr_components/common_components/field-renderer.tsx
@@ -27,7 +27,9 @@ const FieldRenderer = function (props: Props) {
     errorMessage,
     isFormSubmitted,
     isFormRow = true,
-    resetToggle
+    resetToggle,
+    display = true,
+    fadeIn = false
   } = field;
 
   function onACChange(name: string) {
@@ -107,6 +109,8 @@ const FieldRenderer = function (props: Props) {
     }
   }
 
+  if (!display) return <></>;
+
   return (
     <Field
       name={name}
@@ -114,6 +118,7 @@ const FieldRenderer = function (props: Props) {
       gridSize={gridSize}
       required={!!validateValue}
       isFormRow={isFormRow}
+      fadeIn={fadeIn}
     >
       {getFieldMarkup()}
     </Field>

--- a/client/src/ehr_components/data/new-visit-fields.ts
+++ b/client/src/ehr_components/data/new-visit-fields.ts
@@ -1,6 +1,7 @@
 import { labInvOptions, reviewsOptions, yesOrNoOptions } from "./visit";
 
 export interface PatientVisit {
+  id: string;
   patient: string;
   date: string;
   complaint: string;
@@ -70,7 +71,7 @@ export default function generateNewVisitFields(params: NewVisitFieldParams) {
     },
 
     {
-      label: "History of present illness",
+      label: "History of Present Illness",
       placeholder: "Add details about the history of the present illness",
       name: "present_illness_history",
       type: "Textarea",
@@ -78,7 +79,7 @@ export default function generateNewVisitFields(params: NewVisitFieldParams) {
       value: formData.present_illness_history
     },
     {
-      label: "Review of other system",
+      label: "Review of Other System",
       name: "other_system_review",
       type: "Radio",
       value: formData.other_system_review,
@@ -183,7 +184,7 @@ export default function generateNewVisitFields(params: NewVisitFieldParams) {
       value: formData.treatment
     },
     {
-      label: "Is the visit free",
+      label: "Free Visit",
       name: "is_free",
       type: "Radio",
       options: yesOrNoOptions,
@@ -191,7 +192,7 @@ export default function generateNewVisitFields(params: NewVisitFieldParams) {
       value: formData.is_free
     },
     {
-      label: "Is the visit review",
+      label: "Visit Review",
       name: "is_review",
       type: "Radio",
       options: yesOrNoOptions,
@@ -199,7 +200,7 @@ export default function generateNewVisitFields(params: NewVisitFieldParams) {
       value: formData.is_review
     },
     {
-      label: "Is referred from other doctor",
+      label: "Referred",
       name: "is_referred",
       type: "Radio",
       options: yesOrNoOptions,

--- a/client/src/ehr_components/data/patient-history-fields.ts
+++ b/client/src/ehr_components/data/patient-history-fields.ts
@@ -1,0 +1,134 @@
+import { PatientHistory } from "../NewPatient";
+import { yesOrNoOptions } from "./patient-history";
+
+interface PatientHistoryFieldsParams {
+  onChangeHandler: (
+    fieldName: string,
+    event: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
+  ) => void;
+  changedField: string;
+  formData: PatientHistory;
+}
+
+export default function generatePatientHistoryFields(
+  params: PatientHistoryFieldsParams
+) {
+  let { onChangeHandler, changedField, formData } = params;
+
+  let fieldData = [
+    {
+      name: "chronic_diseases"
+    },
+    {
+      label: "Previous Admission to the Hospital",
+      name: "previous_admission",
+      type: "Radio",
+      value: formData.previous_admission,
+      options: yesOrNoOptions,
+      onChange: onChangeHandler
+    },
+    {
+      label: "Previous Admission Description",
+      name: "previous_admission_description",
+      type: "Textarea",
+      placeholder: "Add details about the previous admission",
+      onChange: onChangeHandler,
+      value: formData.previous_admission_description,
+      display: formData.previous_admission === "yes",
+      fadeIn:
+        formData.previous_admission === "yes" &&
+        changedField === "previous_admission"
+    },
+    {
+      label: "Past Surgery",
+      name: "past_surgery",
+      type: "Radio",
+      value: formData.past_surgery,
+      options: yesOrNoOptions,
+      onChange: onChangeHandler
+    },
+    {
+      label: "Past Surgery Description",
+      name: "past_surgery_description",
+      type: "Textarea",
+      placeholder: "Add details about the past surgery",
+      onChange: onChangeHandler,
+      value: formData.past_surgery_description,
+      display: formData.past_surgery === "yes",
+      fadeIn: formData.past_surgery === "yes" && changedField === "past_surgery"
+    },
+    {
+      label: "Fractures",
+      name: "fractures",
+      type: "Textarea",
+      placeholder: "Add details about any past fractures",
+      onChange: onChangeHandler,
+      value: formData.fractures
+    },
+    {
+      label: "Family History",
+      name: "family_history",
+      type: "Textarea",
+      placeholder: "Add details about the family history",
+      onChange: onChangeHandler,
+      value: formData.family_history
+    },
+    {
+      label: "Drug Allergy",
+      name: "drug_allergy",
+      type: "Radio",
+      value: formData.drug_allergy,
+      options: yesOrNoOptions,
+      onChange: onChangeHandler
+    },
+    {
+      label: "Drug Allergy Description",
+      name: "drug_allergy_description",
+      type: "Textarea",
+      placeholder: "Add details about drug allergies",
+      onChange: onChangeHandler,
+      value: formData.drug_allergy_description,
+      display: formData.drug_allergy === "yes",
+      fadeIn: formData.drug_allergy === "yes" && changedField === "drug_allergy"
+    },
+    {
+      label: "Chronic Use of Drugs",
+      name: "chronic_drug_usage",
+      type: "Radio",
+      value: formData.chronic_drug_usage,
+      options: yesOrNoOptions,
+      onChange: onChangeHandler
+    },
+    {
+      name: "blood_group"
+    },
+    {
+      label: "Smoking Status",
+      name: "smoking_status",
+      type: "Radio",
+      value: formData.smoking_status,
+      options: yesOrNoOptions,
+      onChange: onChangeHandler
+    },
+    {
+      label: "Alcohol Drinking",
+      name: "alochol",
+      type: "Radio",
+      value: formData.alcohol,
+      options: yesOrNoOptions,
+      onChange: onChangeHandler
+    },
+    {
+      label: "Notes",
+      name: "notes",
+      type: "Textarea",
+      placeholder: "Add any additional notes",
+      onChange: onChangeHandler,
+      value: formData.notes
+    }
+  ];
+
+  return fieldData;
+}

--- a/client/src/ehr_components/ui/AutoComplete.tsx
+++ b/client/src/ehr_components/ui/AutoComplete.tsx
@@ -21,6 +21,7 @@ interface AutoCompleteProps {
   name?: string;
   placeholder?: string;
   options: any[];
+  defaultSelected?: any[];
   multiple?: boolean;
   onSelect: (select: any) => void;
   onKeyDown?: (e: Event) => void;
@@ -39,6 +40,7 @@ const AutoComplete = forwardRef((props: AutoCompleteProps, ref) => {
     name,
     placeholder,
     options,
+    defaultSelected,
     multiple,
     onSelect,
     onKeyDown,
@@ -57,9 +59,7 @@ const AutoComplete = forwardRef((props: AutoCompleteProps, ref) => {
   });
 
   const handleChange = (selected: any[]) => {
-    if (selected.length !== 0) {
-      onSelect(selected);
-    }
+    onSelect(selected);
   };
 
   const handleBlur = (e: Event) => {
@@ -105,6 +105,7 @@ const AutoComplete = forwardRef((props: AutoCompleteProps, ref) => {
         ref={typeaheadRef}
         id={name}
         options={options ? options : []}
+        defaultSelected={defaultSelected ? defaultSelected : []}
         onChange={handleChange}
         onKeyDown={onKeyDown}
         placeholder={"Search " + placeholder}

--- a/client/src/ehr_components/ui/AutoComplete.tsx
+++ b/client/src/ehr_components/ui/AutoComplete.tsx
@@ -26,6 +26,7 @@ interface AutoCompleteProps {
   onSelect: (select: any) => void;
   onKeyDown?: (e: Event) => void;
   onBlur?: (e: Event) => void;
+  onClear?: () => void;
   className?: string;
 }
 
@@ -45,6 +46,7 @@ const AutoComplete = forwardRef((props: AutoCompleteProps, ref) => {
     onSelect,
     onKeyDown,
     onBlur,
+    onClear,
     className
   } = props;
   const [focus, setFocus] = useState(false);
@@ -67,6 +69,10 @@ const AutoComplete = forwardRef((props: AutoCompleteProps, ref) => {
     setFocus(false);
   };
 
+  const handleClear = () => {
+    onClear && onClear();
+  };
+
   const renderMenu = (results: any[], menuProps: TypeaheadMenuProps<any>) => {
     return (
       <Menu className="shadow" {...menuProps}>
@@ -87,6 +93,7 @@ const AutoComplete = forwardRef((props: AutoCompleteProps, ref) => {
     let handleClearClick = (e: React.MouseEvent<"button", MouseEvent>) => {
       onClear(e);
       onSelect([]);
+      handleClear();
     };
 
     return (

--- a/client/src/ehr_components/ui/Field.tsx
+++ b/client/src/ehr_components/ui/Field.tsx
@@ -5,10 +5,11 @@ export interface FieldProps {
   gridSize?: string;
   required?: boolean;
   isFormRow?: boolean;
+  fadeIn?: boolean;
 }
 
 const Field = (props: FieldProps) => {
-  let { label, name, children, gridSize, required, isFormRow } = props;
+  let { label, name, children, gridSize, required, isFormRow, fadeIn } = props;
 
   let fieldOrientation;
   let labelLength;
@@ -25,7 +26,7 @@ const Field = (props: FieldProps) => {
   if (gridSize) childrenLength = gridSize;
 
   return (
-    <div className={`${fieldOrientation} mb-4`}>
+    <div className={`${fieldOrientation} mb-4 ${fadeIn && "animated fadeIn"}`}>
       <label
         htmlFor={name}
         className={`${labelLength} col-form-label text-left`}

--- a/controllers/patient-controller.ts
+++ b/controllers/patient-controller.ts
@@ -50,11 +50,15 @@ const createPatient: RequestHandler = async (req, res, next) => {
     history: {
       chronic_diseases: "",
       previous_admission: "",
+      previous_admission_description: "",
       past_surgery: "",
+      past_surgery_description: "",
       fractures: "",
       family_history: "",
       drug_allergy: "",
+      drug_allergy_description: "",
       chronic_drug_usage: "",
+      blood_group: "",
       smoking_status: "",
       alcohol: "",
       notes: ""
@@ -82,11 +86,15 @@ const updateHistory: RequestHandler = async (req, res, next) => {
     patient,
     chronic_diseases,
     previous_admission,
+    previous_admission_description,
     past_surgery,
+    past_surgery_description,
     fractures,
     family_history,
     drug_allergy,
+    drug_allergy_description,
     chronic_drug_usage,
+    blood_group,
     smoking_status,
     alcohol,
     notes
@@ -105,19 +113,31 @@ const updateHistory: RequestHandler = async (req, res, next) => {
       .json({ message: "Could not find patient for given patient ID" });
   }
 
-  if (chronic_diseases)
+  if (chronic_diseases !== undefined)
     foundPatient.history.chronic_diseases = chronic_diseases;
-  if (previous_admission)
+  if (previous_admission !== undefined)
     foundPatient.history.previous_admission = previous_admission;
-  if (past_surgery) foundPatient.history.past_surgery = past_surgery;
-  if (fractures) foundPatient.history.fractures = fractures;
-  if (family_history) foundPatient.history.family_history = family_history;
-  if (drug_allergy) foundPatient.history.drug_allergy = drug_allergy;
-  if (chronic_drug_usage)
+  if (previous_admission_description !== undefined)
+    foundPatient.history.previous_admission_description =
+      previous_admission_description;
+  if (past_surgery !== undefined)
+    foundPatient.history.past_surgery = past_surgery;
+  if (past_surgery_description !== undefined)
+    foundPatient.history.past_surgery_description = past_surgery_description;
+  if (fractures !== undefined) foundPatient.history.fractures = fractures;
+  if (family_history !== undefined)
+    foundPatient.history.family_history = family_history;
+  if (drug_allergy !== undefined)
+    foundPatient.history.drug_allergy = drug_allergy;
+  if (drug_allergy_description !== undefined)
+    foundPatient.history.drug_allergy_description = drug_allergy_description;
+  if (chronic_drug_usage !== undefined)
     foundPatient.history.chronic_drug_usage = chronic_drug_usage;
-  if (smoking_status) foundPatient.history.smoking_status = smoking_status;
-  if (alcohol) foundPatient.history.alcohol = alcohol;
-  if (notes) foundPatient.history.notes = notes;
+  if (blood_group !== undefined) foundPatient.history.blood_group = blood_group;
+  if (smoking_status !== undefined)
+    foundPatient.history.smoking_status = smoking_status;
+  if (alcohol !== undefined) foundPatient.history.alcohol = alcohol;
+  if (notes !== undefined) foundPatient.history.notes = notes;
 
   let updatedPatient: (IPatient & Document<any, any, IPatient>) | null;
   try {

--- a/controllers/patient-controller.ts
+++ b/controllers/patient-controller.ts
@@ -47,22 +47,7 @@ const createPatient: RequestHandler = async (req, res, next) => {
     zipCode,
     maritalStatus,
     job,
-    history: {
-      chronic_diseases: "",
-      previous_admission: "",
-      previous_admission_description: "",
-      past_surgery: "",
-      past_surgery_description: "",
-      fractures: "",
-      family_history: "",
-      drug_allergy: "",
-      drug_allergy_description: "",
-      chronic_drug_usage: "",
-      blood_group: "",
-      smoking_status: "",
-      alcohol: "",
-      notes: ""
-    },
+    history: {},
     visits: []
   });
 

--- a/models/PatientModel.ts
+++ b/models/PatientModel.ts
@@ -1,26 +1,34 @@
 import { Types, Schema, model, Document } from "mongoose";
 
 export interface IPatientHistory {
-  chronic_diseases?: string;
+  chronic_diseases?: string[];
   previous_admission?: string;
+  previous_admission_description?: string;
   past_surgery?: string;
+  past_surgery_description?: string;
   fractures?: string;
   family_history?: string;
   drug_allergy?: string;
+  drug_allergy_description?: string;
   chronic_drug_usage?: string;
+  blood_group?: string;
   smoking_status?: string;
   alcohol?: string;
   notes?: string;
 }
 
 export const patientHistorySchema = new Schema({
-  chronic_diseases: { type: String },
+  chronic_diseases: { type: [String] },
   previous_admission: { type: String },
+  previous_admission_description: { type: String },
   past_surgery: { type: String },
+  past_surgery_description: { type: String },
   fractures: { type: String },
   family_history: { type: String },
   drug_allergy: { type: String },
+  drug_allergy_description: { type: String },
   chronic_drug_usage: { type: String },
+  blood_group: { type: String },
   smoking_status: { type: String },
   alcohol: { type: String },
   notes: { type: String }

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,3 @@
+{
+  "signal": "SIGKILL"
+}

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,3 +1,0 @@
-{
-  "signal": "SIGKILL"
-}

--- a/routes/patient-routes.ts
+++ b/routes/patient-routes.ts
@@ -29,7 +29,7 @@ patientRoutes.post(
 );
 
 patientRoutes.patch(
-  "/:patientId",
+  "/history",
   [check("patient").not().isEmpty().withMessage("must not be empty")],
   patientController.updateHistory
 );


### PR DESCRIPTION
This PR updates /main/history to work with the /api and creates /main/visits to display all past visists. A few bugs have also been fixed.

- Empty strings as values for a PATCH to /api/patient/history were disregarded. Empty strings are now correctly saved.
- /main/newVisit was showing mock data for the patient name. The patient name is now correctly shown.
- The patient search table on /main/search wasn't clearing the search when the "x" button was clicked. It now correctly does so.
- Initiailizing a patient's history as an object with values of empty strings when creating a new patient led to incorrect information being shown on /main/history. The patient history is now initialized as an empty object.
- Navigating to /main/visits, /main/newVisit, or /main/history from a URL crashes the app. The app now redirects to /main/search
